### PR TITLE
first parameter of _request() should be an object rather than a string

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -17,7 +17,7 @@ var tests = module.exports = [
 		name: 'Test DiscogsClient._request()',
 		test: function(){
 			var client = new DiscogsClient();
-			client._request('/labels/1', wru.async(function(err, data){
+			client._request({url: '/labels/1'}, wru.async(function(err, data){
 				wru.assert('No error', !err);
 				wru.assert('Correct response data', (data.id && (data.id === 1)));
 			}));


### PR DESCRIPTION
It appears that a test is failing because a string is being sent where an object is expected.
