### PR TITLE
Update client.js

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -62,7 +62,7 @@ function DiscogsClient(userAgent, oauth){
 	// No userAgent provided, but instead we have an accessObject
 	if((arguments.length === 1) && (typeof userAgent === 'object')){ oauth = userAgent; }
 	// Set OAuth data when provided by making a shallow copy of the oauth parameter
-	this.oauth = (typeof oauth === 'object') ? merge({}, oauth) : {version: '1.0', signatureMethod: 'HMAC-SHA1', status: null};
+	this.oauth = (typeof oauth === 'object') ? merge({}, oauth) : {version: '1.0', signatureMethod: 'PLAINTEXT', status: null};
 }
 
 /**
@@ -85,7 +85,7 @@ DiscogsClient.prototype.setConfig = function(customConfig){
  */
  
 DiscogsClient.prototype.getRequestToken = function(consumerKey, consumerSecret, callbackUrl, callback){
-	var oauth = this.oauth, config = (this.customConfig||defaultConfig), oa = new OAuth({consumer: {public: consumerKey, secret: consumerSecret}});
+	var oauth = this.oauth, config = (this.customConfig||defaultConfig), oa = new OAuth({consumer: {public: consumerKey, secret: consumerSecret}, signature_method: oauth.signatureMethod});
 	oauth.consumerKey = consumerKey;
 	oauth.consumerSecret = consumerSecret;
 	this._rawRequest({url: config.oauthRequestUrl+'?oauth_callback='+oa.percentEncode(callbackUrl)}, function(err, data){
@@ -109,7 +109,7 @@ DiscogsClient.prototype.getRequestToken = function(consumerKey, consumerSecret, 
  */
  
 DiscogsClient.prototype.getAccessToken = function(verifier, callback){
-	var oauth = this.oauth, oa = new OAuth({consumer: {public: oauth.consumerKey, secret: oauth.consumerSecret}});
+	var oauth = this.oauth, oa = new OAuth({consumer: {public: oauth.consumerKey, secret: oauth.consumerSecret}, signature_method: oauth.signatureMethod});
 	this._rawRequest({url: (this.customConfig||defaultConfig).oauthAccessUrl+'?oauth_verifier='+oa.percentEncode(verifier)}, function(err, data){
 		if(!err && data){
 			data = queryString.parse(data);
@@ -192,7 +192,7 @@ DiscogsClient.prototype._rawRequest = function(options, callback){
 	
 	// Add Authorization header when authenticated or in the process of authenticating
 	if(this.oauth.consumerKey){
-		var oa = new OAuth({consumer: {public: this.oauth.consumerKey, secret: this.oauth.consumerSecret}}),
+		var oa = new OAuth({consumer: {public: this.oauth.consumerKey, secret: this.oauth.consumerSecret}, signature_method: this.oauth.signatureMethod}),
 			fullUrl = (urlParts.protocol && urlParts.host) ? urlParts.href : 'https://'+config.host+urlParts.path,
 			authObj = oa.authorize({method: method, url: fullUrl}, {public: this.oauth.token, secret: this.oauth.tokenSecret});
 		headers['Authorization'] = oa.toHeader(authObj).Authorization;


### PR DESCRIPTION
Hi,

I'm currently having a problem with connections to the search API endpoint failing with a 401 error. I did some poking around in the Discogs forums, and other people are having the same problem. It seems to be an issue with how they're doing OAuth signatures at that endpoint (and only that endpoint). Here's the forum thread:
http://www.discogs.com/forum/thread/402590

The workaround is to use PLAINTEXT instead of HMAC-SHA1. The oauth1.0a module defaults to HMAC-SHA1 unless you explicitly tell it otherwise, so I had to modify client.js to specify PLAINTEXT.

I'm a single-user application, so I don't have a full oauth infrastructure built out around Disconnect -- I just hacked something together long enough to get my token & then saved the resulting accessData object.

So this implementation works for me and it *should* work for new consumers as well, but I haven't tested it in a full end-to-end OAuth request cycle.

Cheers,

Ross Grady