### PR TITLE
Fixed crash if discogs servers respond with html

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -237,7 +237,7 @@ DiscogsClient.prototype._request = function(options, callback){
 	var self = this, hasCb = (typeof callback === 'function'),
 		doRequest = function(){
 			self._rawRequest(options, function(err, data, rateLimit){
-				if(data && ((typeof options === 'string') || options.json)){
+				if(data && ((typeof options === 'string') || options.json) && data.indexOf('<!') !== 0) {
 					data = JSON.parse(data);
 				}
 				if(hasCb){ callback(err, data, rateLimit); }


### PR DESCRIPTION
Hey there,

Thanks for writing disconnect. It's very useful and elegantly built.

I did run into a problem when Discogs went into maintenance mode which was causing my app to crash every time it got a response from the server.

I looked into it and it's because you were running JSON.parse() on html.

My change is a simple amendment to the if statement after the server response to make sure it's not an html page.

Cheers and thanks again for this awesome module!