### PR TITLE
Fix database.search with different arguments combinations

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -163,12 +163,14 @@ module.exports = function(client){
 		var obj = {};
 		if((arguments.length === 2) && (typeof params === 'function')){
 			callback = params;
-		}else if(params){
-			obj = params;
 		}
-		obj.q = query||'';
-		return client.get({url: util.addParams('/database/search', obj), authLevel: 1}, callback);
-	};
+		if(typeof params === 'object'){
+			obj = params;
+		} else if (typeof query === 'object') {
+			obj = query;
+		}
+		obj.q = typeof query === 'string' ? query : '';
+		return client.get({url: util.addParams('/database/search', obj), authLevel: 1}, callback);	};
 	
 	return database;
 };

--- a/test/client.js
+++ b/test/client.js
@@ -49,6 +49,51 @@ var tests = module.exports = [
 		teardown: function(){
 			nock.cleanAll();
 		}
+	},{
+		name: 'DiscogsClient: Test search without query but with params',
+		test: function(){
+			nock('https://www.example.com').get('/database/search?artist=X&title=Y&q=').reply(200, '{"result": "success"}');
+
+			var client = new DiscogsClient('agent', {consumerKey: 'u', consumerSecret: 'p'}).setConfig({host: 'www.example.com'});
+			var db = client.database();
+			db.search({artist: 'X', title: 'Y'}, wru.async(function(err, data){
+				wru.assert('No error', !err);
+				wru.assert('Correct response data', (data && data.result === 'success'));
+			}));
+		},
+		teardown: function(){
+			nock.cleanAll();
+		}
+	},{
+		name: 'DiscogsClient: Test search with query and params',
+		test: function(){
+			nock('https://www.example.com').get('/database/search?artist=X&title=Y&q=somequery').reply(200, '{"result": "success"}');
+
+			var client = new DiscogsClient('agent', {consumerKey: 'u', consumerSecret: 'p'}).setConfig({host: 'www.example.com'});
+			var db = client.database();
+			db.search('somequery', {artist: 'X', title: 'Y'}, wru.async(function(err, data){
+				wru.assert('No error', !err);
+				wru.assert('Correct response data', (data && data.result === 'success'));
+			}));
+		},
+		teardown: function(){
+			nock.cleanAll();
+		}
+	},{
+		name: 'DiscogsClient: Test search with query only',
+		test: function(){
+			nock('https://www.example.com').get('/database/search?q=somequery').reply(200, '{"result": "success"}');
+
+			var client = new DiscogsClient('agent', {consumerKey: 'u', consumerSecret: 'p'}).setConfig({host: 'www.example.com'});
+			var db = client.database();
+			db.search('somequery', wru.async(function(err, data){
+				wru.assert('No error', !err);
+				wru.assert('Correct response data', (data && data.result === 'success'));
+			}));
+		},
+		teardown: function(){
+			nock.cleanAll();
+		}
 	}
 ];
 


### PR DESCRIPTION
- Allow the database.search method to work with either just query, params, or both
- Add tests for the new combinations

Closes #38  